### PR TITLE
Fix API routing for Render deployment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,7 +44,7 @@ colnames = [
 
 
 # route for fetching all data
-@app.route("/", methods=["GET"] )
+@app.route("/api/data", methods=["GET"] )
 def get_all_data():
     try:
         result = db.session.execute(base_query).fetchall()
@@ -55,7 +55,7 @@ def get_all_data():
 
 
 # route for fetching data by focus objective id
-@app.route('/<int:focus_objective_id>', methods=["GET"])
+@app.route('/api/focus/<int:focus_objective_id>', methods=["GET"])
 def get_data_by_focus_objective(focus_objective_id):
 
     try:
@@ -72,7 +72,7 @@ def get_data_by_focus_objective(focus_objective_id):
 
 
 # route for fetching data by focus objective AND key area
-@app.route('/<int:focus_objective_id>/<int:key_area_id>', methods=["GET"])
+@app.route('/api/focus/<int:focus_objective_id>/<int:key_area_id>', methods=["GET"])
 def get_data_by_key_area(focus_objective_id, key_area_id):
 
     try:
@@ -95,11 +95,10 @@ def serve(path):
    
     if path.startswith('api/'):
         pass
-    elif path != "" and os.path.exists(os.path.join('../frontend/dist', path)):
-        return send_from_directory('../frontend/dist', path)
+    elif path != "" and os.path.exists(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'frontend/dist', path)):
+        return send_from_directory(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'frontend/dist'), path)
     else:
-        return send_from_directory('../frontend/dist', 'index.html')    
-
+        return send_from_directory(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'frontend/dist'), 'index.html')    
 
 if __name__ == "__main__":
     with app.app_context():

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -8,14 +8,14 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Stick+No+Bills:wght@200..800&display=swap" rel="stylesheet">
     <title>EuFMD Milestones Dashboard</title>
-    <script type="module" crossorigin src="/assets/index-BdhA9ZES.js"></script>
+    <script type="module" crossorigin src="/assets/index-BalXYhSg.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/plotly.js-basic-dist-hD-yW4Zm.js">
     <link rel="modulepreload" crossorigin href="/assets/react-Bswn7Xpn.js">
     <link rel="modulepreload" crossorigin href="/assets/scheduler-DYLXRpC5.js">
     <link rel="modulepreload" crossorigin href="/assets/react-dom-Jf2g30Uk.js">
-    <link rel="modulepreload" crossorigin href="/assets/@remix-run-CSkcHbWt.js">
-    <link rel="modulepreload" crossorigin href="/assets/react-router-C45aSSP9.js">
-    <link rel="modulepreload" crossorigin href="/assets/react-router-dom-CTr2x-5s.js">
+    <link rel="modulepreload" crossorigin href="/assets/@remix-run-Ci2Y9YYq.js">
+    <link rel="modulepreload" crossorigin href="/assets/react-router-B8w4gZxk.js">
+    <link rel="modulepreload" crossorigin href="/assets/react-router-dom-DA8c3nkm.js">
     <link rel="modulepreload" crossorigin href="/assets/axios-DW_MHI2K.js">
     <link rel="modulepreload" crossorigin href="/assets/prop-types-BKNjMPK8.js">
     <link rel="modulepreload" crossorigin href="/assets/react-plotly.js-B7WhicGm.js">

--- a/frontend/src/pages/APIFunctions.tsx
+++ b/frontend/src/pages/APIFunctions.tsx
@@ -1,5 +1,5 @@
 // Checks if app is running locally or on Render and uses correct url accordingly
-export const API_URL = window.location.hostname === "localhost"
-    ? "http://localhost:5000"
-    : "https://eufmd-targets.onrender.com/";
-    
+ 
+export const API_URL = window.location.hostname === "localhost" && window.location.port === "5173"
+    ? "http://localhost:5000/api" // When running in Vite dev server
+    : "/api"; // When served by Flask       

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -32,7 +32,7 @@ const Homepage: React.FC = () => {
   // Call API for Focus Objective data
   const getFocus = async () => {
     try {
-      const results = await fetch(`${API_URL}/`, {
+      const results = await fetch(`${API_URL}/data`, {
         method: "GET",
         headers: {"Content-Type": "application/json"},
       });

--- a/frontend/src/pages/KeyAreas.tsx
+++ b/frontend/src/pages/KeyAreas.tsx
@@ -36,7 +36,8 @@ const KeyAreas: React.FC = () => {
   // Get data filtered by focus objective
   const fetchData = async (id: number) => {
     try {
-      const response = await axios.get(`${API_URL}/${id}`);
+      //const response = await axios.get(`${API_URL}/${id}`);
+      const response = await axios.get(`${API_URL}/focus/${id}`);
 
       // Group data by key area so we can map through them. Data will be an array with one object corresponding to each key area id: [ {keyAreaId: id, items: [rows for that key area]}, etc. ]
       const groupedData = groupByKeyArea(response.data);

--- a/frontend/src/pages/Targets.tsx
+++ b/frontend/src/pages/Targets.tsx
@@ -31,7 +31,8 @@ const Targets: React.FC = () => {
   // Get data filtered by focus objective and key area
   const fetchTargetsData = async (focusId: number, keyId: number) => {
     try {
-      const response = await axios.get(`${API_URL}/${focusId}/${keyId}`);
+      //const response = await axios.get(`${API_URL}/${focusId}/${keyId}`);
+      const response = await axios.get(`${API_URL}/focus/${focusId}/key/${keyId}`);
       setTargetsData(response.data);
     } catch (error) {
       console.error('Error fetching data: ', error);


### PR DESCRIPTION
- Added /api prefix to routes in backend/main.py to separate API from frontend routes
- Updated API_URL in frontend/src/pages/APIFunctions.ts to work in both dev and production
- Updated API calls in components (Homepage.tsx, KeyAreas.tsx, Targets.tsx) to match new route structure
- Updated serve fuction in backend/main.py to correctly handle static files from frontend/dist